### PR TITLE
Add dynamic catalog.json generator and CI workflow

### DIFF
--- a/.github/workflows/catalog.yml
+++ b/.github/workflows/catalog.yml
@@ -1,0 +1,33 @@
+name: Update Catalog
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "0[1-4]-*/*.py"
+      - "scripts/generate_catalog.py"
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Generate catalog.json
+        run: python scripts/generate_catalog.py
+
+      - name: Commit if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/catalog.json
+          if git diff --cached --quiet; then
+            echo "No catalog changes"
+          else
+            git commit -m "chore: regenerate catalog.json"
+            git push
+          fi

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -1,0 +1,331 @@
+[
+  {
+    "tier": "01-foundations",
+    "name": "attention_vs_none",
+    "display": "Attention vs None",
+    "thesis": "Attention is not just helpful -- it is the mechanism that lets a model look back across an",
+    "lines": 511
+  },
+  {
+    "tier": "01-foundations",
+    "name": "microbert",
+    "display": "BERT",
+    "thesis": "The other half of the transformer — how BERT learns bidirectional representations by predicting",
+    "lines": 501
+  },
+  {
+    "tier": "01-foundations",
+    "name": "microconv",
+    "display": "CNN",
+    "thesis": "How a sliding kernel extracts spatial features — the convolution operation, pooling, and feature",
+    "lines": 549
+  },
+  {
+    "tier": "01-foundations",
+    "name": "microdiffusion",
+    "display": "Denoising Diffusion",
+    "thesis": "How images emerge from noise -- the denoising diffusion algorithm behind Stable Diffusion,",
+    "lines": 461
+  },
+  {
+    "tier": "01-foundations",
+    "name": "microembedding",
+    "display": "Word Embeddings",
+    "thesis": "How meaning becomes geometry — training vectors where distance equals similarity,",
+    "lines": 377
+  },
+  {
+    "tier": "01-foundations",
+    "name": "microgan",
+    "display": "GAN",
+    "thesis": "Two networks at war -- how a generator learns to fool a discriminator, and why the",
+    "lines": 534
+  },
+  {
+    "tier": "01-foundations",
+    "name": "microgpt",
+    "display": "Autoregressive GPT",
+    "thesis": "The autoregressive language model from first principles: GPT learns to predict the next",
+    "lines": 513
+  },
+  {
+    "tier": "01-foundations",
+    "name": "microlstm",
+    "display": "LSTM",
+    "thesis": "Long Short-Term Memory from first principles: the 4-gate architecture that solved the",
+    "lines": 530
+  },
+  {
+    "tier": "01-foundations",
+    "name": "microoptimizer",
+    "display": "Optimizer Comparison",
+    "thesis": "Why Adam converges when SGD stalls — momentum, adaptive learning rates, and the geometry of",
+    "lines": 585
+  },
+  {
+    "tier": "01-foundations",
+    "name": "microrag",
+    "display": "RAG Pipeline",
+    "thesis": "How retrieval augments generation -- the simplest system that actually works, with BM25",
+    "lines": 521
+  },
+  {
+    "tier": "01-foundations",
+    "name": "microresnet",
+    "display": "ResNet",
+    "thesis": "Residual networks from first principles: skip connections as gradient highways — proving",
+    "lines": 740
+  },
+  {
+    "tier": "01-foundations",
+    "name": "micrornn",
+    "display": "RNN vs GRU",
+    "thesis": "Before attention conquered everything -- how sequences were modeled with recurrence, and why",
+    "lines": 507
+  },
+  {
+    "tier": "01-foundations",
+    "name": "microtokenizer",
+    "display": "BPE Tokenizer",
+    "thesis": "How text becomes numbers -- the compression algorithm hiding inside every LLM.",
+    "lines": 193
+  },
+  {
+    "tier": "01-foundations",
+    "name": "microvae",
+    "display": "VAE",
+    "thesis": "How to learn a compressed, generative representation of data — the reparameterization",
+    "lines": 510
+  },
+  {
+    "tier": "01-foundations",
+    "name": "microvit",
+    "display": "Vision Transformer",
+    "thesis": "Vision Transformer from first principles: an image is worth 16x16 words — treating",
+    "lines": 655
+  },
+  {
+    "tier": "01-foundations",
+    "name": "rnn_vs_gru_vs_lstm",
+    "display": "RNN vs GRU vs LSTM",
+    "thesis": "Three generations of recurrent architectures on the same task: vanilla RNN fails at long-range",
+    "lines": 647
+  },
+  {
+    "tier": "02-alignment",
+    "name": "adam_vs_sgd",
+    "display": "Adam vs SGD",
+    "thesis": "Adam converges faster than SGD because it maintains per-parameter learning rates that adapt",
+    "lines": 469
+  },
+  {
+    "tier": "02-alignment",
+    "name": "microbatchnorm",
+    "display": "Batch Normalization",
+    "thesis": "How normalizing activations within each mini-batch stabilizes training and enables deeper networks.",
+    "lines": 457
+  },
+  {
+    "tier": "02-alignment",
+    "name": "microdpo",
+    "display": "DPO",
+    "thesis": "Direct Preference Optimization (DPO): aligning a language model with human preferences using",
+    "lines": 614
+  },
+  {
+    "tier": "02-alignment",
+    "name": "microdropout",
+    "display": "Dropout",
+    "thesis": "Why randomly destroying neurons during training prevents overfitting — dropout, weight decay,",
+    "lines": 475
+  },
+  {
+    "tier": "02-alignment",
+    "name": "microgrpo",
+    "display": "GRPO",
+    "thesis": "How DeepSeek simplified RLHF — group-based reward normalization that eliminates the value",
+    "lines": 541
+  },
+  {
+    "tier": "02-alignment",
+    "name": "microlora",
+    "display": "LoRA",
+    "thesis": "Low-Rank Adaptation (LoRA): fine-tuning a frozen language model by injecting tiny trainable",
+    "lines": 498
+  },
+  {
+    "tier": "02-alignment",
+    "name": "micromoe",
+    "display": "Mixture of Experts",
+    "thesis": "Mixture of Experts (MoE): a router network learns to dispatch each token to a subset of",
+    "lines": 562
+  },
+  {
+    "tier": "02-alignment",
+    "name": "microppo",
+    "display": "PPO (RLHF)",
+    "thesis": "The full RLHF loop: pretrain a language model, train a reward model on human preferences,",
+    "lines": 802
+  },
+  {
+    "tier": "02-alignment",
+    "name": "microqlora",
+    "display": "QLoRA",
+    "thesis": "How to fine-tune a 4-bit quantized model with full-precision LoRA adapters — the technique",
+    "lines": 671
+  },
+  {
+    "tier": "02-alignment",
+    "name": "microreinforce",
+    "display": "REINFORCE",
+    "thesis": "The simplest policy gradient algorithm -- how log-probability weighting turns reward signals",
+    "lines": 465
+  },
+  {
+    "tier": "03-systems",
+    "name": "microattention",
+    "display": "Attention Variants",
+    "thesis": "Every attention mechanism that matters, side by side: how MHA, GQA, MQA, and sliding",
+    "lines": 368
+  },
+  {
+    "tier": "03-systems",
+    "name": "microbeam",
+    "display": "Beam Search",
+    "thesis": "Beyond greedy: six decoding strategies for language model text generation, from deterministic",
+    "lines": 622
+  },
+  {
+    "tier": "03-systems",
+    "name": "microbm25",
+    "display": "BM25",
+    "thesis": "The evolution of text retrieval scoring: from raw term frequency through TF-IDF to BM25,",
+    "lines": 618
+  },
+  {
+    "tier": "03-systems",
+    "name": "microcheckpoint",
+    "display": "Activation Checkpointing",
+    "thesis": "How to train models twice as deep on the same hardware — trading compute for memory",
+    "lines": 484
+  },
+  {
+    "tier": "03-systems",
+    "name": "microcomplexssm",
+    "display": "Complex SSM",
+    "thesis": "A complex-valued state space model is mathematically identical to a real-valued one with",
+    "lines": 600
+  },
+  {
+    "tier": "03-systems",
+    "name": "microdiscretize",
+    "display": "Discretization",
+    "thesis": "The choice of discretization method changes what a recurrence can learn — Euler, ZOH,",
+    "lines": 625
+  },
+  {
+    "tier": "03-systems",
+    "name": "microflash",
+    "display": "Flash Attention",
+    "thesis": "Flash Attention computes exact attention identical to standard attention, but processes",
+    "lines": 358
+  },
+  {
+    "tier": "03-systems",
+    "name": "microkv",
+    "display": "KV-Cache",
+    "thesis": "Why autoregressive generation recomputes redundant work at every step, and how the KV cache",
+    "lines": 476
+  },
+  {
+    "tier": "03-systems",
+    "name": "micropaged",
+    "display": "PagedAttention",
+    "thesis": "How vLLM serves thousands of concurrent requests -- paged memory allocation for KV-caches",
+    "lines": 502
+  },
+  {
+    "tier": "03-systems",
+    "name": "microparallel",
+    "display": "Model Parallelism",
+    "thesis": "How models that exceed single-device memory get distributed — tensor parallelism, pipeline",
+    "lines": 490
+  },
+  {
+    "tier": "03-systems",
+    "name": "microquant",
+    "display": "Quantization",
+    "thesis": "How to shrink a model by 4x with minimal quality loss -- the math behind INT8 and INT4",
+    "lines": 588
+  },
+  {
+    "tier": "03-systems",
+    "name": "microroofline",
+    "display": "Roofline Model",
+    "thesis": "A state update running 100x more FLOPs can be faster on real hardware if it shifts from",
+    "lines": 834
+  },
+  {
+    "tier": "03-systems",
+    "name": "microrope",
+    "display": "RoPE",
+    "thesis": "How position information gets baked into attention through rotation matrices — why RoPE",
+    "lines": 325
+  },
+  {
+    "tier": "03-systems",
+    "name": "microspeculative",
+    "display": "Speculative Decoding",
+    "thesis": "Speculative decoding from first principles: a small draft model proposes tokens that a",
+    "lines": 798
+  },
+  {
+    "tier": "03-systems",
+    "name": "microssm",
+    "display": "State Space Models",
+    "thesis": "The alternative to attention -- how state space models process sequences in linear time",
+    "lines": 510
+  },
+  {
+    "tier": "03-systems",
+    "name": "microvectorsearch",
+    "display": "Vector Search",
+    "thesis": "Vector search from first principles: exact brute-force nearest neighbors vs approximate",
+    "lines": 472
+  },
+  {
+    "tier": "04-agents",
+    "name": "microbandit",
+    "display": "Multi-Armed Bandit",
+    "thesis": "Multi-armed bandits from first principles: three strategies — Epsilon-Greedy, UCB1, and",
+    "lines": 574
+  },
+  {
+    "tier": "04-agents",
+    "name": "micromcts",
+    "display": "Monte Carlo Tree Search",
+    "thesis": "Monte Carlo Tree Search from first principles: the algorithm behind AlphaGo's game play —",
+    "lines": 522
+  },
+  {
+    "tier": "04-agents",
+    "name": "micromemory",
+    "display": "Memory-Augmented Network",
+    "thesis": "Memory-augmented neural networks from first principles: a Neural Turing Machine learns to",
+    "lines": 930
+  },
+  {
+    "tier": "04-agents",
+    "name": "microminimax",
+    "display": "Minimax + Alpha-Beta",
+    "thesis": "Adversarial search from first principles: minimax with alpha-beta pruning learns to play",
+    "lines": 830
+  },
+  {
+    "tier": "04-agents",
+    "name": "microreact",
+    "display": "ReAct",
+    "thesis": "The ReAct reasoning loop from first principles: Thought -> Action -> Observation as a",
+    "lines": 893
+  }
+]

--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -1,0 +1,125 @@
+"""
+Generate catalog.json from all algorithm scripts in the repository.
+
+Extracts tier, filename, display name, and thesis docstring from each .py file
+in the tier directories. Output is written to docs/catalog.json and consumed
+by the no-magic-ai.github.io website.
+
+Usage:
+    python scripts/generate_catalog.py
+"""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TIER_DIRS = ["01-foundations", "02-alignment", "03-systems", "04-agents"]
+OUTPUT = REPO_ROOT / "docs" / "catalog.json"
+
+DISPLAY_OVERRIDES = {
+    "microgpt": "Autoregressive GPT",
+    "micrornn": "RNN vs GRU",
+    "microlstm": "LSTM",
+    "microtokenizer": "BPE Tokenizer",
+    "microembedding": "Word Embeddings",
+    "microrag": "RAG Pipeline",
+    "microbert": "BERT",
+    "microconv": "CNN",
+    "microdiffusion": "Denoising Diffusion",
+    "microgan": "GAN",
+    "microoptimizer": "Optimizer Comparison",
+    "microvae": "VAE",
+    "microvit": "Vision Transformer",
+    "microresnet": "ResNet",
+    "microlora": "LoRA",
+    "microdpo": "DPO",
+    "microppo": "PPO (RLHF)",
+    "micromoe": "Mixture of Experts",
+    "microbatchnorm": "Batch Normalization",
+    "microdropout": "Dropout",
+    "microgrpo": "GRPO",
+    "microqlora": "QLoRA",
+    "microreinforce": "REINFORCE",
+    "microattention": "Attention Variants",
+    "microbeam": "Beam Search",
+    "microflash": "Flash Attention",
+    "microkv": "KV-Cache",
+    "microquant": "Quantization",
+    "microrope": "RoPE",
+    "microssm": "State Space Models",
+    "microcheckpoint": "Activation Checkpointing",
+    "micropaged": "PagedAttention",
+    "microparallel": "Model Parallelism",
+    "microbm25": "BM25",
+    "microcomplexssm": "Complex SSM",
+    "microdiscretize": "Discretization",
+    "microroofline": "Roofline Model",
+    "microspeculative": "Speculative Decoding",
+    "microvectorsearch": "Vector Search",
+    "microbandit": "Multi-Armed Bandit",
+    "micromcts": "Monte Carlo Tree Search",
+    "micromemory": "Memory-Augmented Network",
+    "microminimax": "Minimax + Alpha-Beta",
+    "microreact": "ReAct",
+    "attention_vs_none": "Attention vs None",
+    "adam_vs_sgd": "Adam vs SGD",
+    "rnn_vs_gru_vs_lstm": "RNN vs GRU vs LSTM",
+}
+
+
+def name_to_display(name: str) -> str:
+    """Convert a script name to a human-readable display name."""
+    if name in DISPLAY_OVERRIDES:
+        return DISPLAY_OVERRIDES[name]
+    # Fallback: strip 'micro' prefix and title-case
+    clean = name.replace("micro", "", 1) if name.startswith("micro") else name
+    return clean.replace("_", " ").title()
+
+
+def extract_thesis(path: Path) -> str:
+    """Extract the first line of the module docstring."""
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    docstring = ast.get_docstring(tree)
+    if not docstring:
+        return ""
+    # Take the first sentence (up to first period followed by space/newline, or first newline)
+    first_line = docstring.strip().split("\n")[0].strip()
+    return first_line
+
+
+def count_lines(path: Path) -> int:
+    """Count non-empty lines in a script."""
+    return sum(1 for line in path.read_text(encoding="utf-8").splitlines() if line.strip())
+
+
+def build_catalog() -> list[dict]:
+    """Scan all tier directories and build the catalog."""
+    catalog = []
+    for tier in TIER_DIRS:
+        tier_path = REPO_ROOT / tier
+        if not tier_path.exists():
+            continue
+        for script in sorted(tier_path.glob("*.py")):
+            name = script.stem
+            catalog.append({
+                "tier": tier,
+                "name": name,
+                "display": name_to_display(name),
+                "thesis": extract_thesis(script),
+                "lines": count_lines(script),
+            })
+    return catalog
+
+
+def main() -> None:
+    catalog = build_catalog()
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT.write_text(json.dumps(catalog, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(f"Generated {OUTPUT} with {len(catalog)} algorithms")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- `scripts/generate_catalog.py` — extracts tier, name, display name, thesis, and line count from all algorithm scripts into `docs/catalog.json`
- `.github/workflows/catalog.yml` — auto-regenerates `catalog.json` on push to main when any `.py` file in tier directories changes
- `docs/catalog.json` — initial generated catalog (47 algorithms)

The [no-magic-ai.github.io](https://no-magic-ai.github.io) website fetches this JSON at load time, so adding a new algorithm script automatically updates the website after the CI workflow runs.

## Test plan

- [x] `python scripts/generate_catalog.py` produces valid JSON with all 47 algorithms
- [ ] CI workflow triggers on push to main when tier scripts change
- [ ] Website loads catalog dynamically from raw.githubusercontent.com