### PR TITLE
ci: grant write permission to catalog generator job

### DIFF
--- a/.github/workflows/catalog.yml
+++ b/.github/workflows/catalog.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   generate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

Fixes the `Update Catalog` workflow, which has been failing on every push to `main` that touches `0[1-4]-*/*.py` or `scripts/generate_catalog.py`. The generator step succeeds, but the subsequent `git push` fails with HTTP 403 because the default `GITHUB_TOKEN` is read-only.

Reference failing run: https://github.com/no-magic-ai/no-magic/actions/runs/24640876735/job/72044527262

## Root cause

Token permissions in the failing run (from the workflow log header):

```
GITHUB_TOKEN Permissions
  Contents: read
  Metadata: read
  Packages: read
```

The `catalog.yml` workflow regenerates `docs/catalog.json` and commits it back to `main`. Without an explicit `permissions:` block, GitHub Actions grants the workflow read-only token scope, so the final `git push` is rejected:

```
remote: Permission to no-magic-ai/no-magic.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/no-magic-ai/no-magic/': The requested URL returned error: 403
```

## Change

Grant `contents: write` scoped to the `generate` job only:

```yaml
jobs:
  generate:
    runs-on: ubuntu-latest
    permissions:
      contents: write
    steps:
      - uses: actions/checkout@v4
      ...
```

## Why job-level, not workflow-level

Declaring `permissions:` at the job level rather than at the top of the workflow keeps any future jobs on the default read-only scope. Principle of least privilege — only the job that actually pushes gets write access.

## Recursion safety

The workflow auto-commits `docs/catalog.json`, but the trigger path filter is limited to:

```yaml
paths:
  - "0[1-4]-*/*.py"
  - "scripts/generate_catalog.py"
```

`docs/catalog.json` is not in that list, so the bot's commit will not re-trigger the workflow. No loop risk.

## Files changed

- `.github/workflows/catalog.yml` — +2 lines (job-scoped `permissions: contents: write`)

## Test plan

- [ ] Merge to `main`.
- [ ] Next push to any `0[1-4]-*/*.py` or `scripts/generate_catalog.py` should trigger `Update Catalog` and succeed through the push step.
- [ ] Alternatively, re-run the failing job from the Actions UI after this lands to verify the regenerated `docs/catalog.json` commits cleanly.
- [ ] Confirm no second workflow run is triggered by the bot's auto-commit (path filter should prevent recursion).

## Out of scope

- Converting `catalog.json` from a committed artifact to a build-time artifact (would eliminate the need to push from CI entirely, but changes the site-build contract — separate PR).
- Upgrading the deprecated Node.js 20 actions flagged by the runner warning in the same log.